### PR TITLE
Added new config settings for each tier for ShouldUseOnlyGuaranteedItems

### DIFF
--- a/ItemRoulette/Configs/ConfigBase.cs
+++ b/ItemRoulette/Configs/ConfigBase.cs
@@ -12,13 +12,14 @@ namespace ItemRoulette.Configs
         }
 
         public abstract string SectionName { get; }
+        public virtual string SectionKey => "{0}";
         public virtual string SectionDescription => "{0}";
 
         public abstract void Initialize();
 
-        public ConfigEntry<T> Bind<T>(string key, T defaultValue, string descriptionExtraThing)
+        public ConfigEntry<T> Bind<T>(string keyExtraThing, T defaultValue, string descriptionExtraThing)
         {
-            return Bind(SectionName, key, defaultValue, string.Format(SectionDescription, descriptionExtraThing));
+            return Bind(SectionName, string.Format(SectionKey, keyExtraThing), defaultValue, string.Format(SectionDescription, descriptionExtraThing));
         }
 
         public ConfigEntry<T> Bind<T>(string section, string key, T defaultValue, string description)

--- a/ItemRoulette/Configs/ConfigSettings.cs
+++ b/ItemRoulette/Configs/ConfigSettings.cs
@@ -16,7 +16,7 @@ namespace ItemRoulette.Configs
             GeneralSettings = new General(config);
             ItemTierCountSettings = new ItemTierCount(config);
             ItemTagPercentsSettings = new ItemTagPercents(config);
-            GuaranteedItemsSettings = new GuaranteedItems(config, logger);
+            GuaranteedItemsSettings = new GuaranteedItemsCombined(config, logger);
 
             _configs.Add(GeneralSettings);
             _configs.Add(ItemTierCountSettings);
@@ -27,7 +27,7 @@ namespace ItemRoulette.Configs
         internal General GeneralSettings { get; private set; }
         internal ItemTierCount ItemTierCountSettings { get; private set; }
         internal ItemTagPercents ItemTagPercentsSettings { get; private set; }
-        internal GuaranteedItems GuaranteedItemsSettings { get; private set; }
+        internal GuaranteedItemsCombined GuaranteedItemsSettings { get; private set; }
 
         public void InitializeConfigFile(bool shouldReloadConfig = false)
         {

--- a/ItemRoulette/Configs/GuaranteedItemsCombined.cs
+++ b/ItemRoulette/Configs/GuaranteedItemsCombined.cs
@@ -1,0 +1,47 @@
+﻿using BepInEx.Configuration;
+using BepInEx.Logging;
+using RoR2;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace ItemRoulette.Configs
+{
+    internal class GuaranteedItemsCombined : ConfigBase
+    {
+        private GuaranteedItems _guaranteedItems;
+        private GuaranteedItemsShouldUse _guaranteedItemsShouldUse;
+        private IDictionary<ItemTier, ReadOnlyCollection<PickupIndex>> _guaranteedItemsDictionary;
+        private IDictionary<ItemTier, bool> _guaranteedItemsShouldUseDictionary;
+
+        public GuaranteedItemsCombined(ConfigFile config, ManualLogSource logger) : base(config) 
+        {
+            _guaranteedItemsShouldUse = new GuaranteedItemsShouldUse();
+            _guaranteedItems = new GuaranteedItems(logger);
+        }
+
+        public override string SectionName => "Guaranteed Items";
+
+        public override void Initialize()
+        {
+            _guaranteedItemsShouldUse.Initialize(Bind);
+            _guaranteedItemsShouldUseDictionary = _guaranteedItemsShouldUse.GetGuaranteedItemsShouldOnlyUseDictionary();
+
+            _guaranteedItems.Initialize(Bind);
+            _guaranteedItemsDictionary = _guaranteedItems.GetGuaranteedItemsDictionary();
+        }
+
+        public List<(ItemTier ItemTier, bool ShouldUseOnlyGuaranteedItems, ReadOnlyCollection<PickupIndex> GuaranteedItems)> GetGuaranteedItemSettings()
+        {
+            var guaranteedItemSettings = new List<(ItemTier, bool, ReadOnlyCollection<PickupIndex>)>();
+
+            foreach (var guaranteedItemsShouldUse in _guaranteedItemsShouldUseDictionary)
+            {
+                _guaranteedItemsDictionary.TryGetValue(guaranteedItemsShouldUse.Key, out var guaranteedItems);
+
+                guaranteedItemSettings.Add((guaranteedItemsShouldUse.Key, guaranteedItemsShouldUse.Value, guaranteedItems));
+            }
+
+            return guaranteedItemSettings;
+        }
+    }
+}

--- a/ItemRoulette/Configs/GuaranteedItemsShouldUse.cs
+++ b/ItemRoulette/Configs/GuaranteedItemsShouldUse.cs
@@ -1,0 +1,46 @@
+﻿using BepInEx.Configuration;
+using RoR2;
+using System;
+using System.Collections.Generic;
+
+namespace ItemRoulette.Configs
+{
+    internal class GuaranteedItemsShouldUse
+    {
+        private ConfigEntry<bool> _shouldOnlyUseGuaranteedItemsTier1;
+        private ConfigEntry<bool> _shouldOnlyUseGuaranteedItemsTier2;
+        private ConfigEntry<bool> _shouldOnlyUseGuaranteedItemsTier3;
+        private ConfigEntry<bool> _shouldOnlyUseGuaranteedItemsBoss;
+        private ConfigEntry<bool> _shouldOnlyUseGuaranteedItemsLunar;
+
+        private const string SECTION_KEY = "Should only use guaranteed items for {0}";
+        private const string SECTION_DESCRIPTION = "Set to TRUE if you want to ONLY use the items for {0} and nothing else. Set to FALSE if you want the items for {0} to be added to the randomly generated items";
+        
+        public bool ShouldOnlyUseGuaranteedItemsTier1 => _shouldOnlyUseGuaranteedItemsTier1.Value;
+        public bool ShouldOnlyUseGuaranteedItemsTier2 => _shouldOnlyUseGuaranteedItemsTier2.Value;
+        public bool ShouldOnlyUseGuaranteedItemsTier3 => _shouldOnlyUseGuaranteedItemsTier3.Value;
+        public bool ShouldOnlyUseGuaranteedItemsBoss => _shouldOnlyUseGuaranteedItemsBoss.Value;
+        public bool ShouldOnlyUseGuaranteedItemsLunar => _shouldOnlyUseGuaranteedItemsLunar.Value;
+
+        public void Initialize(Func<string, bool, string, ConfigEntry<bool>> bind)
+        {
+            _shouldOnlyUseGuaranteedItemsTier1 = bind(string.Format(SECTION_KEY, "Tier 1"), false, string.Format(SECTION_DESCRIPTION, "Tier 1"));
+            _shouldOnlyUseGuaranteedItemsTier2 = bind(string.Format(SECTION_KEY, "Tier 2"), false, string.Format(SECTION_DESCRIPTION, "Tier 2"));
+            _shouldOnlyUseGuaranteedItemsTier3 = bind(string.Format(SECTION_KEY, "Tier 3"), false, string.Format(SECTION_DESCRIPTION, "Tier 3"));
+            _shouldOnlyUseGuaranteedItemsBoss = bind(string.Format(SECTION_KEY, "Boss"), false, string.Format(SECTION_DESCRIPTION, "Boss"));
+            _shouldOnlyUseGuaranteedItemsLunar = bind(string.Format(SECTION_KEY, "Lunar"), false, string.Format(SECTION_DESCRIPTION, "Lunar"));
+        }
+
+        public IDictionary<ItemTier, bool> GetGuaranteedItemsShouldOnlyUseDictionary()
+        {
+            return new Dictionary<ItemTier, bool>
+            {
+                { ItemTier.Tier1, ShouldOnlyUseGuaranteedItemsTier1 },
+                { ItemTier.Tier2, ShouldOnlyUseGuaranteedItemsTier2 },
+                { ItemTier.Tier3, ShouldOnlyUseGuaranteedItemsTier3 },
+                { ItemTier.Boss, ShouldOnlyUseGuaranteedItemsBoss },
+                { ItemTier.Lunar, ShouldOnlyUseGuaranteedItemsLunar }
+            };
+        }
+    }
+}

--- a/ItemRoulette/Configs/ItemTagPercents.cs
+++ b/ItemRoulette/Configs/ItemTagPercents.cs
@@ -17,6 +17,7 @@ namespace ItemRoulette.Configs
         public ItemTagPercents(ConfigFile config) : base(config) { }
 
         public override string SectionName => "Item Tag Percents";
+        public override string SectionKey => "{0} Type Percentage";
         public override string SectionDescription => "Determines what percent of total items available between Tiers 1, 2, and 3 will be of the {0} type. 0 means no items of that type";
 
         public double TotalPercentageOfItems => PercentageOfDamageItems + PercentageOfHealingItems + PercentageOfUtilityItems;
@@ -26,9 +27,9 @@ namespace ItemRoulette.Configs
 
         public override void Initialize()
         {
-            _percentageOfDamageItems = Bind("DamageTypePercentage", 33d, "Damage");
-            _percentageOfUtilityItems = Bind("UtilityTypePercentage", 33d, "Utility");
-            _percentageOfHealingItems = Bind("HealingTypePercentage", 33d, "Healing");
+            _percentageOfDamageItems = Bind("Damage", 33d, "Damage");
+            _percentageOfUtilityItems = Bind("Utility", 33d, "Utility");
+            _percentageOfHealingItems = Bind("Healing", 33d, "Healing");
 
             _percentagesOfItems.Clear();
             _percentagesOfItems.Add(_percentageOfDamageItems);

--- a/ItemRoulette/Configs/ItemTierCount.cs
+++ b/ItemRoulette/Configs/ItemTierCount.cs
@@ -13,6 +13,7 @@ namespace ItemRoulette.Configs
         public ItemTierCount(ConfigFile configFile) : base(configFile) { }
 
         public override string SectionName => "New Total Item Counts";
+        public override string SectionKey => "{0} New Count";
         public override string SectionDescription => "This is number of items that will be available for {0}. The items in the run will be pulled at random from all unlocked items in this tier. Set to 0 to have all unlocked items in the run.";
         
         public int TotalItemCountForTiers123 => Tier1ItemCount + Tier2ItemCount + Tier3ItemCount;
@@ -24,11 +25,11 @@ namespace ItemRoulette.Configs
 
         public override void Initialize()
         {
-            _tier1ItemCount = Bind("Tier1NewCount", 5, "Tier1 items");
-            _tier2ItemCount = Bind("Tier2NewCount", 3, "Tier2 items");
-            _tier3ItemCount = Bind("Tier3NewCount", 1, "Tier3 items");
-            _bossItemCount = Bind("BossNewCount", 0, "Boss items");
-            _lunarItemCount = Bind("LunarNewCount", 0, "Lunar items");
+            _tier1ItemCount = Bind("Tier 1", 5, "Tier1 items");
+            _tier2ItemCount = Bind("Tier 2", 3, "Tier2 items");
+            _tier3ItemCount = Bind("Tier 3", 1, "Tier3 items");
+            _bossItemCount = Bind("Boss", 0, "Boss items");
+            _lunarItemCount = Bind("Lunar", 0, "Lunar items");
         }
     }
 }

--- a/ItemRoulette/Hooks/Catalogs.cs
+++ b/ItemRoulette/Hooks/Catalogs.cs
@@ -1,0 +1,45 @@
+﻿using ItemRoulette.Configs;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Hook = On.RoR2;
+
+namespace ItemRoulette.Hooks
+{
+    internal class Catalogs
+    {
+        private readonly ConfigSettings _configSettings;
+        private readonly HookStateTracker _hookStateTracker;
+
+        public Catalogs(ConfigSettings configSettings, HookStateTracker hookStateTracker)
+        {
+            _configSettings = configSettings;
+            _hookStateTracker = hookStateTracker;
+        }
+
+        public void OnItemCatalogInit(Hook.ItemCatalog.orig_Init orig)
+        {
+            orig();
+            _hookStateTracker.IsItemCatalogInitDone = true;
+
+            if (_hookStateTracker.IsItemCatalogInitDone && _hookStateTracker.IsPickupCatalogInitDone)
+                GenerateItemLists();
+        }
+
+        public void OnPickupCatalogInit(Hook.PickupCatalog.orig_Init orig)
+        {
+            orig();
+            _hookStateTracker.IsPickupCatalogInitDone = true;
+
+            if (_hookStateTracker.IsItemCatalogInitDone && _hookStateTracker.IsPickupCatalogInitDone)
+                GenerateItemLists();
+        }
+
+        private void GenerateItemLists()
+        {
+            ItemInfos.GenerateItemLists();
+            _configSettings.InitializeConfigFile();
+        }
+    }
+}

--- a/ItemRoulette/Hooks/HookStateTracker.cs
+++ b/ItemRoulette/Hooks/HookStateTracker.cs
@@ -1,0 +1,12 @@
+﻿namespace ItemRoulette.Hooks
+{
+    internal class HookStateTracker
+    {
+        public bool IsBuildDropTableDone { get; set; } = false;
+        public bool IsMonsterGenerateAvailableItemsSetDone { get; set; } = false;
+        public bool IsItemCatalogInitDone { get; set; } = false;
+        public bool IsPickupCatalogInitDone { get; set; } = false;
+        
+        public int CurrentLoopCount { get; set; } = 0;
+    }
+}

--- a/ItemRoulette/ItemRoulette.cs
+++ b/ItemRoulette/ItemRoulette.cs
@@ -12,29 +12,29 @@ namespace ItemRoulette
 {
     [BepInDependency("com.bepis.r2api", BepInDependency.DependencyFlags.HardDependency)]
     [BepInProcess("Risk of Rain 2.exe")]
-    [BepInPlugin("com.zeusesneckmeat.itemroulette", "ItemRoulette", "2.1.0.0")]
+    [BepInPlugin("com.zeusesneckmeat.itemroulette", "ItemRoulette", "2.3.0.0")]
     public class ItemRoulette : BaseUnityPlugin
     {
         private ConfigSettings _configSettings;
-
-        private CustomHooks.Run _run;
 
         public void Awake()
         {
             _configSettings = new ConfigSettings(Config, Logger);
 
+            var hookStateTracker = new CustomHooks.HookStateTracker();
             var customDropTable = new CustomDropTable(Logger, _configSettings);
-            _run = new CustomHooks.Run(Logger, _configSettings, customDropTable);
+            var run = new CustomHooks.Run(Logger, _configSettings, customDropTable, hookStateTracker);
+            var catalogs = new CustomHooks.Catalogs(_configSettings, hookStateTracker);
 
             Hook.ArenaMissionController.OnStartServer += customDropTable.OnArenaStartServer;
             Hook.Console.Awake += (orig, self) => orig(self);
-            Hook.ItemCatalog.Init += _run.OnItemCatalogInit;
-            Hook.PickupCatalog.Init += _run.OnPickupCatalogInit;
-            Hook.Run.BeginStage += _run.OnBeginStage;
-            Hook.Run.BuildDropTable += _run.OnBuildDropTable;
-            Hook.Run.OnDestroy += _run.OnRunDestroy;
+            Hook.ItemCatalog.Init += catalogs.OnItemCatalogInit;
+            Hook.PickupCatalog.Init += catalogs.OnPickupCatalogInit;
+            Hook.Run.BeginStage += run.OnBeginStage;
+            Hook.Run.BuildDropTable += run.OnBuildDropTable;
+            Hook.Run.OnDestroy += run.OnRunDestroy;
 
-            MonsterTeamGainsItemsArtifactManager.GenerateAvailableItemsSet += _run.OnGenerateAvailableItemsSet;
+            MonsterTeamGainsItemsArtifactManager.GenerateAvailableItemsSet += run.OnGenerateAvailableItemsSet;
         }
 
         void Update()

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These options should provide a little more variety for longer runs, if wanted. E
 
 There is a new section in the config file called `Guaranteed Items`. This section will show you all of the items generated for each tier with a number next to them. You can specify any number of items per tier, and you would place the numbers of that items into the config setting. These items will be added as "extra" items to that tier. So if you specify 5 items for `Tier 1` and you have `Paul's Goat Hoof` as your guaranteed item, then `Tier 1` will have 6 total items.
 
-Along with being able to set guaranteed items per tier, there is also a setting for whether or not you want the items you've set as guaranteed to be the ***only*** items in that tier. So for whatever reason if you want to have `Soldier's Syringe` as your only `Tier 1` item, then you would add it's number to the appropriate setting, and set `Should only use guaranteed items` to `true`. This will ignore your `Tier 1` settings while you have both `Should only use guaranteed items` set to `true` and any item numbers in any of the settings in this section.
+Along with being able to set guaranteed items per tier, there is also a setting for whether or not you want the items you've set as guaranteed to be the ***only*** items in that tier. So for whatever reason if you want to have `Soldier's Syringe` as your only `Tier 1` item, then you would add it's number to the appropriate setting, and set `Should only use guaranteed items for Tier 1` to `true`. This will ignore your `Tier 1` settings while you have both `Should only use guaranteed items for Tier 1` set to `true` and any item numbers in the `Tier 1 Guaranteed Items` section of the settings in this section. Each Tier has its own setting for "Should Use" and "Guaranteed Items"
 
 To add multiple items for each tier you would enter each number of the item in the appropriate section, separated by just a comma. For example, if you want `1: Soldier's Syringe` and `2: Paul's Goat Hoof` as your items you would enter `1,2` as your values for the `Tier 1` items. These numbers for these items are just examples and not the real values. (The "real" values can also change with mods that install more items as well) 
 
@@ -71,6 +71,12 @@ The above updates aren't exactly small, but I will try to work on them when I ha
 If you find any bugs, incompatibilities with other mods, or just general suggestions please feel free to add them to the [Issues section](https://github.com/ZeusesNeckMeat/RiskOfRain2-ItemRoulette/issues) in Github!
 	
 ## Changelog
+
+**2.3.0**
+* Refactored the custom hooks to split some into separate files that made more sense
+* Added a new CustomHookTracker class to track the state of the game to be used by each custom hooks
+* Added SectionKey as a virtual property on ConfigBase to more easily expand upon adding new configs with keys
+* Added a new set of configs to be able to control whether or not you want to use only the guaranteed items at a specific tier level, so each tier can be controlled separately
 
 **2.2.0**
 * Updated Guaranteed Items config to allow multiple items through a comma delimited list


### PR DESCRIPTION
- Refactored the custom hooks to split some into separate files that made more sense
- Added a new CustomHookTracker class to track the state of the game to be used by each custom hooks
- Added SectionKey as a virtual property on ConfigBase to more easily expand upon adding new configs with keys
- Added a new set of configs to be able to control whether or not you want to use only the guaranteed items at a specific tier level, so each tier can be controlled separately